### PR TITLE
Return an error code when failures are detected.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -5,7 +5,7 @@ pub struct CommandParser {
 impl CommandParser {
     pub fn from_command(cmd: &str) -> Self {
         Self {
-            command_parts: cmd.split(" ").map(|s| s.to_owned()).collect(),
+            command_parts: cmd.split(' ').map(|s| s.to_owned()).collect(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::{
     opt::{Opt, StructOpt},
 };
 
-fn main() {
+fn main() -> Result<(), &'static str> {
     let opt = Opt::from_args();
 
     let (tx, rx) = crossbeam_channel::unbounded();
@@ -45,4 +45,10 @@ fn main() {
     println!("Failure: {}/{}", failure_count, total_count);
 
     runner::join_threads(handles);
+
+    if failure_count > 0 {
+        Err("Flaky tests detected")
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
The exit code returned from `detect_flake` can be indicative of whether
there was flakiness when executing the command. This expands
accessibility of using this tool in automated test systems.