### PR TITLE
Add ability to exit early when error encountered

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,12 @@ fn main() -> Result<(), &'static str> {
                 }
             }
             Message::FailedToRun(error) => {
+                bar.println(error);
+
                 if opt.exit_early_on_error {
                     process::exit(1);
                 } else {
                     failure_count += 1;
-                    bar.println(error);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ mod message;
 mod opt;
 mod runner;
 
+use std::process;
+
 use indicatif::ProgressBar;
 
 use crate::{
@@ -28,12 +30,20 @@ fn main() -> Result<(), &'static str> {
             Message::ExitStatusSuccess => {
                 success_count += 1;
             }
-            Message::ExitStatusFailure => {
-                failure_count += 1;
+            Message::ExitStatusFailure(code) => {
+                if opt.exit_early_on_error {
+                    process::exit(code.unwrap_or(1));
+                } else {
+                    failure_count += 1;
+                }
             }
             Message::FailedToRun(error) => {
-                failure_count += 1;
-                bar.println(error);
+                if opt.exit_early_on_error {
+                    process::exit(1);
+                } else {
+                    failure_count += 1;
+                    bar.println(error);
+                }
             }
         }
         bar.inc(1);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 #[derive(Debug)]
 pub enum Message {
     ExitStatusSuccess,
-    ExitStatusFailure,
+    ExitStatusFailure(Option<i32>),
     FailedToRun(String),
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -25,4 +25,8 @@ pub struct Opt {
     /// Print the stdout and stderr of unsucessful runs only
     #[clap(short, long, conflicts_with = "inherit_stdio")]
     pub print_failing_output: bool,
+
+    /// Exit early the first time the command returns a non-zero error code
+    #[clap(short, long)]
+    pub exit_early_on_error: bool,
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -50,7 +50,7 @@ pub fn start_threads(opt: &Opt, tx: Sender<Message>) -> Vec<JoinHandle<()>> {
                                 eprintln!("----------------------------------------");
                                 io::stderr().write(&output.stderr).unwrap();
                             }
-                            Message::ExitStatusFailure
+                            Message::ExitStatusFailure(output.status.code())
                         }
                     }
                     Err(error) => Message::FailedToRun(error.to_string()),


### PR DESCRIPTION
This adds an `--exit-early-on-error` CLI flag that will cause `detect_flake` to exit early if the command being run returns an error or fails to run entirely. At ReadySet, we're using this tool to find the exact commit that introduced a particular build failure, and being able to end the `detect_flake` build step at the first error will significantly speed up the process.

Here are some assumptions I made while writing this change:
* When exit early mode is enabled, it's useful for `detect_flake` to return the same status code returned from the command being run (I pass this command status through the crossbeam channel so the main thread has it)
* We still want to display the progress bar as we run the tests

P.S. It looks like you're building really cool stuff at Prisma 😄  